### PR TITLE
Limited self consistency check

### DIFF
--- a/public/js/EditorLogger.js
+++ b/public/js/EditorLogger.js
@@ -64,9 +64,8 @@ function EditorLogger(){
       //before we do anything there are some edge case we need to take care of specifically \nabla^2 need to be formatted as \nabla \cdot \nabla
       let ls = FormatNablaSquared(MathFields[id].mf.latex());
       ls = PutBracketsAroundAllSubsSupsAndRemoveEmptySubsSups(ls);
-      ls = RemoveDifferentialOperatorDFromLatexString(ls);
       if(ls.length > 0){//there is something to evaluate
-        let undefinedVars = GetUndefinedVariables(ls);
+        let undefinedVars = GetUndefinedVariables(RemoveDifferentialOperatorDFromLatexString(ls));
         this.recordUndefinedVariables(undefinedVars);
         CheckForErrorsInExpression(ls, lineNumber, id);
       }
@@ -110,9 +109,8 @@ function EditorLogger(){
         //before we do anything there are some edge case we need to take care of specifically \nabla^2 need to be formatted as \nabla \cdot \nabla
         let ls = FormatNablaSquared(MathFields[id].mf.latex());
         ls = PutBracketsAroundAllSubsSupsAndRemoveEmptySubsSups(ls);
-        ls = RemoveDifferentialOperatorDFromLatexString(ls);
         if(ls.length > 0){//there is something to evaluate
-          let undefinedVars = GetUndefinedVariables(ls);
+          let undefinedVars = GetUndefinedVariables(RemoveDifferentialOperatorDFromLatexString(ls));
           this.recordUndefinedVariables(undefinedVars);
           CheckForErrorsInExpression(ls, lineNumber, id);
         }
@@ -140,7 +138,8 @@ function EditorLogger(){
             c++;
           }
         }
-        console.log("expressionsThatDontEqualEachOtherOnThisLine", expressionsThatDontEqualEachOtherOnThisLine);
+
+        //console.log("expressionsThatDontEqualEachOtherOnThisLine", expressionsThatDontEqualEachOtherOnThisLine);
         if(expressionsThatDontEqualEachOtherOnThisLine.length > 0){
           this.addLog({error: [{
             error: EL.createLoggerErrorFromMathJsError("Expressions are not equivalent"),

--- a/public/js/ejsTemplates.js
+++ b/public/js/ejsTemplates.js
@@ -221,4 +221,8 @@ let Templates = {
     </table>
   </div>
   `,
+  "no-variables-defined":
+  `
+  <div id="no-variables-defined" class="center">The physics constants you import and variables you use in the editor will appear in this tab</div>
+  `,
 };

--- a/public/js/functions.js
+++ b/public/js/functions.js
@@ -656,8 +656,8 @@ function PutBracketsAroundAllSubsSupsAndRemoveEmptySubsSups(ls){
     i++;
   }
 
-  ls = ls.replace(/_\{(\s|\\)*}/g,"");//remnoving all empty subscripts from latex string
-  ls = ls.replace(/\^\{(\s|\\)*}/g,"");//remnoving all empty superscripts from latex string
+  ls = ls.replace(/_\{(\s|\\)*}/g," ");//remnoving all empty subscripts from latex string
+  ls = ls.replace(/\^\{(\s|\\)*}/g," ");//remnoving all empty superscripts from latex string
   return ls;
 }
 

--- a/public/js/functions.js
+++ b/public/js/functions.js
@@ -806,6 +806,9 @@ function OrderCompileAndRenderMyVariablesCollection(){
   }
 
   //RENDER
+  if(html == ""){//if there are no variables defined we will just show a nice message to the user so they know whats up
+    html = ejs.render(Templates["no-variables-defined"]);
+  }
   $("#my_variables-collection-container .collection").html(html);//rendering new collection
   //Add event listeners and initialize static math fields
   $("#my_variables .collection span").each(function(){


### PR DESCRIPTION
Added limited self consistency checks for most expressions and indefinite and definite integrals. These self consistency checks act more as a way to check that the student's simplifications make sense because it can only relate expressions that use the same variables. For example if a user writes "x = 2x" the editor will send an error. but if the user writes "y=2x" then on another line they write "y=x" it wont throw an error.